### PR TITLE
Fix vector clock to preserve all device entries on update

### DIFF
--- a/Sources/BearCLICore/CloudKitAPI.swift
+++ b/Sources/BearCLICore/CloudKitAPI.swift
@@ -542,66 +542,15 @@ public struct CloudKitAPI {
 
     // MARK: - Vector Clock Helpers
 
-    /// Create a fresh vector clock for a new record.
+    /// Create a fresh vector clock for a new record (used only for note creation).
     private func makeVectorClock(device: String, counter: Int) -> String {
-        // Minimal binary plist: { "Bear CLI": counter }
-        // The format Bear uses is a bplist00 with the device name and an int counter.
-        // We replicate the exact pattern from Bear Web's output.
-        var data = Data()
-        // bplist00 header
-        data.append(contentsOf: [0x62, 0x70, 0x6C, 0x69, 0x73, 0x74, 0x30, 0x30])
-        // ASCII string object (type 0x50 + length)
-        let deviceBytes = Array(device.utf8)
-        data.append(UInt8(0x50 | (deviceBytes.count & 0x0F)))
-        data.append(contentsOf: deviceBytes)
-        // Int object (type 0x10 + value)
-        data.append(0x10)
-        data.append(UInt8(counter & 0xFF))
-        // Offset table and trailer (simplified)
-        let obj0Offset: UInt8 = 8
-        let obj1Offset = obj0Offset + 1 + UInt8(deviceBytes.count)
-        // Dict with 1 entry: key=obj0, value=obj1
-        data.append(0xD1) // dict with 1 entry
-        data.append(0x00) // key index
-        data.append(0x01) // value index
-        // Offset table
-        let offsetTableOffset = data.count
-        data.append(obj0Offset)
-        data.append(obj1Offset)
-        data.append(obj1Offset + 2) // dict offset
-        // Trailer (32 bytes)
-        data.append(contentsOf: [UInt8](repeating: 0, count: 18))
-        data.append(0x01) // offsetIntSize
-        data.append(0x01) // objectRefSize
-        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03]) // numObjects
-        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02]) // topObject index
-        let otBytes = withUnsafeBytes(of: UInt64(offsetTableOffset).bigEndian) { Array($0) }
-        data.append(contentsOf: otBytes)
-        return data.base64EncodedString()
+        let clock: [String: Int] = [device: counter]
+        return VectorClock.encode(clock)
     }
 
     /// Increment the counter in an existing vector clock, or create a fresh one.
     private func incrementVectorClock(_ base64: String) -> String {
-        // The clock is a bplist with {"Device Name": counter}.
-        // We create a new clock with "Bear CLI" and counter = extracted + 1.
-        // If we can't parse the existing clock, preserve it unchanged to avoid
-        // creating a conflict that causes Bear desktop to reject the update.
-        guard let data = Data(base64Encoded: base64), data.count > 20 else {
-            return makeVectorClock(device: "Bear CLI", counter: 1)
-        }
-
-        // Try to find the counter byte (it follows 0x10 pattern)
-        // The counter is typically near the device name, encoded as 0x10 + byte
-        for i in 9..<(data.count - 20) {
-            if data[i] == 0x10 {
-                let currentCounter = Int(data[i + 1])
-                return makeVectorClock(device: "Bear CLI", counter: currentCounter + 1)
-            }
-        }
-
-        // Could not parse the clock — return it unchanged rather than resetting
-        // to counter=1, which would look like a conflict to other Bear clients
-        return base64
+        return VectorClock.increment(base64, device: "Bear CLI")
     }
 
     // MARK: - Zone Changes (incremental sync)

--- a/Sources/BearCLICore/VectorClock.swift
+++ b/Sources/BearCLICore/VectorClock.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Bear's vector clock is a binary plist dictionary mapping device names to integer counters.
+/// When updating a note, the clock must preserve all existing device entries and add/update
+/// the editing device's counter to be greater than all existing values. Failing to preserve
+/// entries causes Bear desktop to treat the update as a conflict and silently reject it.
+public enum VectorClock {
+
+    /// Decode a base64-encoded binary plist vector clock into a dictionary.
+    public static func decode(_ base64: String) -> [String: Int]? {
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil
+        ) else { return nil }
+
+        // Bear stores the clock as {String: Int} but PropertyListSerialization
+        // may decode values as various NSNumber types.
+        guard let raw = plist as? [String: Any] else { return nil }
+        var result: [String: Int] = [:]
+        for (key, value) in raw {
+            if let n = value as? Int {
+                result[key] = n
+            } else if let n = value as? NSNumber {
+                result[key] = n.intValue
+            }
+        }
+        return result
+    }
+
+    /// Encode a vector clock dictionary to a base64-encoded binary plist.
+    public static func encode(_ clock: [String: Int]) -> String {
+        guard let data = try? PropertyListSerialization.data(
+            fromPropertyList: clock, format: .binary, options: 0
+        ) else {
+            // Fallback: empty clock should never happen, but don't crash
+            return ""
+        }
+        return data.base64EncodedString()
+    }
+
+    /// Increment a base64-encoded vector clock for the given device.
+    /// Preserves all existing device entries. Sets the device's counter
+    /// to max(all existing counters) + 1.
+    public static func increment(_ base64: String, device: String) -> String {
+        guard let clock = decode(base64) else {
+            // Can't parse — create a fresh clock rather than silently corrupting
+            return encode([device: 1])
+        }
+
+        var updated = clock
+        let maxCounter = clock.values.max() ?? 0
+        updated[device] = maxCounter + 1
+        return encode(updated)
+    }
+}

--- a/Tests/BearCLITests/VectorClockTests.swift
+++ b/Tests/BearCLITests/VectorClockTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import BearCLICore
+
+final class VectorClockTests: XCTestCase {
+
+    // MARK: - Round-trip encode/decode
+
+    func testEncodeDecodeRoundTrip() {
+        let clock: [String: Int] = ["Kevin's MacBook Pro": 42, "Bear CLI": 3]
+        let encoded = VectorClock.encode(clock)
+        let decoded = VectorClock.decode(encoded)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?["Kevin's MacBook Pro"], 42)
+        XCTAssertEqual(decoded?["Bear CLI"], 3)
+    }
+
+    func testSingleDeviceRoundTrip() {
+        let clock: [String: Int] = ["Bear CLI": 1]
+        let encoded = VectorClock.encode(clock)
+        let decoded = VectorClock.decode(encoded)
+
+        XCTAssertEqual(decoded, ["Bear CLI": 1])
+    }
+
+    // MARK: - Increment preserves all devices
+
+    func testIncrementPreservesExistingDevices() {
+        let original: [String: Int] = ["Kevin's MacBook Pro": 10, "Kevin's iPhone": 5]
+        let base64 = VectorClock.encode(original)
+
+        let incremented = VectorClock.increment(base64, device: "Bear CLI")
+        let result = VectorClock.decode(incremented)
+
+        XCTAssertNotNil(result)
+        // Original devices preserved
+        XCTAssertEqual(result?["Kevin's MacBook Pro"], 10)
+        XCTAssertEqual(result?["Kevin's iPhone"], 5)
+        // New device gets max + 1
+        XCTAssertEqual(result?["Bear CLI"], 11)
+    }
+
+    func testIncrementExistingDevice() {
+        let original: [String: Int] = ["Bear CLI": 3, "Kevin's MacBook Pro": 7]
+        let base64 = VectorClock.encode(original)
+
+        let incremented = VectorClock.increment(base64, device: "Bear CLI")
+        let result = VectorClock.decode(incremented)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?["Kevin's MacBook Pro"], 7)
+        // Bear CLI updated to max(3,7) + 1 = 8
+        XCTAssertEqual(result?["Bear CLI"], 8)
+    }
+
+    // MARK: - Counter values > 255
+
+    func testLargeCounterValues() {
+        let original: [String: Int] = ["Kevin's MacBook Pro": 500]
+        let base64 = VectorClock.encode(original)
+
+        let incremented = VectorClock.increment(base64, device: "Bear CLI")
+        let result = VectorClock.decode(incremented)
+
+        XCTAssertEqual(result?["Kevin's MacBook Pro"], 500)
+        XCTAssertEqual(result?["Bear CLI"], 501)
+    }
+
+    // MARK: - Invalid input handling
+
+    func testIncrementInvalidBase64() {
+        let result = VectorClock.increment("not-valid-base64!!!", device: "Bear CLI")
+        let decoded = VectorClock.decode(result)
+
+        // Should create a fresh clock
+        XCTAssertEqual(decoded?["Bear CLI"], 1)
+    }
+
+    func testIncrementEmptyString() {
+        let result = VectorClock.increment("", device: "Bear CLI")
+        let decoded = VectorClock.decode(result)
+
+        XCTAssertEqual(decoded?["Bear CLI"], 1)
+    }
+
+    func testDecodeInvalidBase64ReturnsNil() {
+        XCTAssertNil(VectorClock.decode("not-valid"))
+    }
+
+    func testDecodeNonPlistReturnsNil() {
+        // Valid base64 but not a plist
+        let base64 = Data("hello world".utf8).base64EncodedString()
+        XCTAssertNil(VectorClock.decode(base64))
+    }
+
+    // MARK: - Many devices
+
+    func testManyDevices() {
+        let original: [String: Int] = [
+            "Kevin's MacBook Pro": 50,
+            "Kevin's iPhone": 30,
+            "Kevin's iPad": 20,
+            "Bear Web": 5,
+        ]
+        let base64 = VectorClock.encode(original)
+
+        let incremented = VectorClock.increment(base64, device: "Bear CLI")
+        let result = VectorClock.decode(incremented)
+
+        XCTAssertEqual(result?.count, 5)
+        XCTAssertEqual(result?["Kevin's MacBook Pro"], 50)
+        XCTAssertEqual(result?["Kevin's iPhone"], 30)
+        XCTAssertEqual(result?["Kevin's iPad"], 20)
+        XCTAssertEqual(result?["Bear Web"], 5)
+        XCTAssertEqual(result?["Bear CLI"], 51)
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where `bcli edit` updates succeed on CloudKit but Bear desktop silently rejects them
- Root cause: `incrementVectorClock()` replaced the entire vector clock with a single device entry, discarding counters from other devices (MacBook, iPhone, iPad, etc). Bear treats missing device entries as a conflict/rollback.
- Secondary issue: naive byte scanning for bplist `0x10` integer markers could match non-counter bytes and truncated counters above 255

## Changes

- Extracted `VectorClock` into a standalone public type using `PropertyListSerialization` for proper binary plist encode/decode
- `increment()` preserves all existing device entries and sets "Bear CLI" to `max(all counters) + 1`
- Simplified `CloudKitAPI` to delegate to `VectorClock` for both `makeVectorClock` and `incrementVectorClock`
- Added 10 unit tests covering round-trips, multi-device preservation, large counters (>255), and invalid input

## Test plan

**Automated:**
- `swift test` — all 28 tests pass (18 existing + 10 new VectorClock tests)

**Manual reproduction:**
1. Find a note with edits from multiple devices (has multi-device vector clock)
2. Run `bcli edit NOTE_ID --append "test line"` with the old binary
3. Observe: Bear desktop does NOT show the appended text (even after restart)
4. Build with this fix: `swift build`
5. Run `bcli edit NOTE_ID --append "test line 2"` with the new binary
6. Observe: Bear desktop picks up the change within seconds (no restart needed)

**Verify vector clock preservation:**
```bash
# Before fix: clock becomes {"Bear CLI": N} (single entry)
# After fix: clock preserves {"Kevin's MacBook Pro": 50, "Bear CLI": 51, ...}
```