### PR TITLE
Surface per-record CloudKit errors from modify operations

### DIFF
--- a/Sources/BearCLICore/CloudKitAPI.swift
+++ b/Sources/BearCLICore/CloudKitAPI.swift
@@ -213,8 +213,19 @@ public struct CloudKitAPI {
             "zoneID": .dictionary(["zoneName": .string("Notes")]),
         ]
 
-        let response: CKRecordQueryResponse = try await post(path: "records/modify", body: body)
-        return response.records
+        let response: CKModifyResponse = try await post(path: "records/modify", body: body)
+
+        // Check for per-record errors (conflicts, etc.)
+        let errors = response.records.filter { $0.isError }
+        if let first = errors.first {
+            throw BearCLIError.recordError(
+                recordName: first.recordName,
+                serverErrorCode: first.serverErrorCode ?? "UNKNOWN",
+                reason: first.reason ?? "No reason provided"
+            )
+        }
+
+        return response.records.compactMap { $0.toRecord() }
     }
 
     /// Create a new note. Returns the created CKRecord.
@@ -662,6 +673,7 @@ public enum BearCLIError: Error, CustomStringConvertible {
     case networkError(String)
     case invalidURL(String)
     case noteNotFound(String)
+    case recordError(recordName: String, serverErrorCode: String, reason: String)
 
     public var description: String {
         switch self {
@@ -677,6 +689,8 @@ public enum BearCLIError: Error, CustomStringConvertible {
             return "Invalid URL: \(url)"
         case .noteNotFound(let id):
             return "Note not found: \(id)"
+        case .recordError(let recordName, let code, let reason):
+            return "CloudKit record error on \(recordName): \(code) — \(reason)"
         }
     }
 }

--- a/Sources/BearCLICore/Models.swift
+++ b/Sources/BearCLICore/Models.swift
@@ -102,6 +102,44 @@ public struct CKRecordLookupResponse: Decodable {
     public let records: [CKRecord]
 }
 
+/// Response from CloudKit /records/modify endpoint.
+/// Each record entry may be a success (with fields) or a per-record error
+/// (with serverErrorCode and reason). We parse both.
+public struct CKModifyResponse: Decodable {
+    public let records: [CKModifyRecordResult]
+}
+
+public struct CKModifyRecordResult: Decodable {
+    public let recordName: String
+    public let recordType: String?
+    public let fields: [String: CKRecordField]?
+    public let recordChangeTag: String?
+    public let created: CKTimestamp?
+    public let modified: CKTimestamp?
+    public let deleted: Bool?
+    // Per-record error fields returned by CloudKit on conflict/failure
+    public let serverErrorCode: String?
+    public let reason: String?
+
+    public var isError: Bool {
+        serverErrorCode != nil
+    }
+
+    /// Convert a successful result into a CKRecord.
+    public func toRecord() -> CKRecord? {
+        guard !isError else { return nil }
+        return CKRecord(
+            recordName: recordName,
+            recordType: recordType,
+            fields: fields ?? [:],
+            recordChangeTag: recordChangeTag,
+            created: created,
+            modified: modified,
+            deleted: deleted
+        )
+    }
+}
+
 public struct CKRecord: Decodable {
     public let recordName: String
     public let recordType: String?

--- a/Tests/BearCLITests/ModelsTests.swift
+++ b/Tests/BearCLITests/ModelsTests.swift
@@ -219,3 +219,76 @@ final class SyncStatsTests: XCTestCase {
         XCTAssertTrue(stats.summary.contains("2 deleted"))
     }
 }
+
+final class CKModifyResponseTests: XCTestCase {
+
+    func testSuccessfulResult() throws {
+        let json = """
+        {
+            "records": [{
+                "recordName": "note-1",
+                "recordType": "SFNote",
+                "fields": {
+                    "title": {"value": "Test", "type": "STRING"}
+                },
+                "recordChangeTag": "abc123"
+            }]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CKModifyResponse.self, from: json)
+        XCTAssertEqual(response.records.count, 1)
+        XCTAssertFalse(response.records[0].isError)
+        XCTAssertNotNil(response.records[0].toRecord())
+        XCTAssertEqual(response.records[0].toRecord()?.recordName, "note-1")
+    }
+
+    func testErrorResult() throws {
+        let json = """
+        {
+            "records": [{
+                "recordName": "note-1",
+                "serverErrorCode": "CONFLICT",
+                "reason": "record changed by another device"
+            }]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CKModifyResponse.self, from: json)
+        XCTAssertEqual(response.records.count, 1)
+        XCTAssertTrue(response.records[0].isError)
+        XCTAssertEqual(response.records[0].serverErrorCode, "CONFLICT")
+        XCTAssertEqual(response.records[0].reason, "record changed by another device")
+        XCTAssertNil(response.records[0].toRecord())
+    }
+
+    func testMixedResults() throws {
+        let json = """
+        {
+            "records": [
+                {
+                    "recordName": "note-1",
+                    "recordType": "SFNote",
+                    "fields": {},
+                    "recordChangeTag": "tag1"
+                },
+                {
+                    "recordName": "note-2",
+                    "serverErrorCode": "CONFLICT",
+                    "reason": "stale change tag"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CKModifyResponse.self, from: json)
+        XCTAssertEqual(response.records.count, 2)
+
+        let successes = response.records.compactMap { $0.toRecord() }
+        let errors = response.records.filter { $0.isError }
+
+        XCTAssertEqual(successes.count, 1)
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors[0].recordName, "note-2")
+    }
+}


### PR DESCRIPTION
## Summary

- `modifyRecords()` now detects and surfaces per-record CloudKit errors instead of silently ignoring them
- Previously, `bcli edit` could report "Updated" while CloudKit actually rejected the update due to a conflict or stale `recordChangeTag`
- Adds `CKModifyResponse` / `CKModifyRecordResult` models that parse both successful records and error fields (`serverErrorCode`, `reason`)
- New `BearCLIError.recordError` case provides actionable error messages

## Changes

- `Models.swift`: Add `CKModifyResponse` and `CKModifyRecordResult` with `serverErrorCode`/`reason` parsing
- `CloudKitAPI.swift`: `modifyRecords()` uses the new response type and throws on per-record errors
- `CloudKitAPI.swift`: Add `recordError` case to `BearCLIError`
- `ModelsTests.swift`: 3 new tests for success, error, and mixed response parsing

## Test plan

**Automated:**
- `swift test` — all 21 tests pass (18 existing + 3 new CKModifyResponse tests)

**Manual reproduction:**
1. Edit a note on another device (or directly in Bear) to change its `recordChangeTag`
2. Run `bcli edit NOTE_ID --append "test"` with the old binary
3. Observe: bcli prints "Updated" but Bear doesn't show the change (silent failure)
4. Build with this fix: `swift build`
5. Repeat step 2 with the new binary
6. Observe: bcli now throws `CloudKit record error on NOTE_ID: CONFLICT — record changed by another device` instead of silently succeeding