### PR TITLE
Fix Bear app not detecting note changes from CLI

### DIFF
--- a/Sources/BearCLICore/CloudKitAPI.swift
+++ b/Sources/BearCLICore/CloudKitAPI.swift
@@ -369,6 +369,10 @@ public struct CloudKitAPI {
                 "value": .string(existingUniqueID),
                 "type": .string("STRING"),
             ]),
+            "text": .dictionary([
+                "value": .null,
+                "type": .string("STRING"),
+            ]),
         ]
 
         var recordDict: [String: AnyCodableValue] = [


### PR DESCRIPTION
## Problem
Bear desktop doesn't detect note changes made via CLI. When updating note content via `textADP`, the old `text` asset field still points to stale content, so Bear reads the old asset URL instead of the new content.

## Fix
- Set the `text` asset field to null in `updateNote` when editing so Bear doesn't read stale content from the old asset URL