### PR TITLE
Fix release binary version mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i '' "s/version: \".*\"/version: \"$VERSION\"/" Sources/BearCLICore/Exports.swift
+
       - name: Build release binary
         run: swift build -c release --arch arm64 --arch x86_64
 


### PR DESCRIPTION
## Problem
Release binaries can report the wrong version. `softprops/action-gh-release` does not overwrite existing assets — if a release is created manually with a stale binary first, the CI-built binary upload is silently skipped.

## Fix
- Inject version from the git tag (`GITHUB_REF_NAME`) into `Exports.swift` before building, so the binary always matches the tag regardless of what's hardcoded in source