### PR TITLE
Remove unnecessary 6s delay from auth server shutdown

### DIFF
--- a/Sources/BearCLICore/AuthServer.swift
+++ b/Sources/BearCLICore/AuthServer.swift
@@ -585,9 +585,6 @@ public class AuthServer {
                 tokenLock.unlock()
                 respond(clientSocket, status: 200, statusText: "OK",
                         contentType: "application/json", body: "{\"status\":\"ok\"}")
-                // Delay shutdown so the browser receives the response and
-                // the countdown JS can run before the CLI process exits.
-                Thread.sleep(forTimeInterval: 6.0)
                 shouldStop = true
             } else {
                 respond(clientSocket, status: 400, statusText: "Bad Request",


### PR DESCRIPTION
## Summary

- Removes the `Thread.sleep(forTimeInterval: 6.0)` after receiving the auth token in `AuthServer.swift`
- The delay was unnecessary: `respond()` writes all bytes to the kernel's TCP send buffer via `send()`, and `close()` triggers a graceful TCP FIN that flushes the buffer before teardown
- The browser countdown JS runs entirely client-side with no further server requests, so the server doesn't need to stay alive

Addresses feedback from @mreider in https://github.com/mreider/better-bear-cli/pull/9#issuecomment-4209455575

## Test plan

- [ ] Run `bcli auth` and complete Apple Sign-In flow
- [ ] Verify the CLI exits promptly after receiving the token (no 6s hang)
- [ ] Verify the browser still shows the "Authenticated!" countdown and fallback message