### PR TITLE
Fix tag-index staleness, body-edit corruption, and phantom SFNoteTag records

### DIFF
--- a/Sources/BearCLICore/CloudKitAPI.swift
+++ b/Sources/BearCLICore/CloudKitAPI.swift
@@ -201,6 +201,30 @@ public struct CloudKitAPI {
         return response.records
     }
 
+    /// Look up a single `SFNoteTag` by its `title` field. Returns nil if no
+    /// such tag exists. Uses a server-side filter so it stays O(1) on the
+    /// wire regardless of how many tags the user has.
+    public func findTagRecord(byName name: String) async throws -> CKRecord? {
+        let query = CKQuery(
+            recordType: "SFNoteTag",
+            filterBy: [
+                CKFilter(
+                    fieldName: "title",
+                    comparator: "EQUALS",
+                    fieldValue: CKFieldValue(value: .string(name), type: "STRING")
+                ),
+            ],
+            sortBy: nil
+        )
+        let request = CKRecordQueryRequest(
+            zoneID: bearZone,
+            query: query,
+            resultsLimit: 1
+        )
+        let response: CKRecordQueryResponse = try await post(path: "records/query", body: request)
+        return response.records.first
+    }
+
     // MARK: - Lookup by ID
 
     public func lookupRecords(ids: [String], desiredKeys: [String]? = nil) async throws -> [CKRecord] {
@@ -361,6 +385,25 @@ public struct CloudKitAPI {
         }
 
         return response.records.compactMap { $0.toRecord() }
+    }
+
+    /// Permanently delete a record from the Notes zone. Uses CloudKit's
+    /// `forceDelete` op so the call succeeds without a matching
+    /// `recordChangeTag` — suitable for removing `SFNoteTag` records whose
+    /// change-tag we may not have cached.
+    ///
+    /// Note-level deletion in bcli is soft (see `trashNote` — sets `trashed`
+    /// true via an update). `deleteRecord` is only used today for removing
+    /// tag records, where a hard delete matches the user expectation that
+    /// `bear delete <tag>` makes the tag disappear from Bear's sidebar.
+    public func deleteRecord(recordName: String) async throws {
+        let operation: [String: AnyCodableValue] = [
+            "operationType": .string("forceDelete"),
+            "record": .dictionary([
+                "recordName": .string(recordName),
+            ]),
+        ]
+        _ = try await modifyRecords(operations: [operation])
     }
 
     /// Create a new note. Returns the created CKRecord.

--- a/Sources/BearCLICore/Commands/TagCommand.swift
+++ b/Sources/BearCLICore/Commands/TagCommand.swift
@@ -241,20 +241,37 @@ struct TagRename: ParsableCommand {
             let engine = SyncEngine(api: api)
             let cache = try await engine.ensureCacheReady()
 
-            let oldHash = oldName.contains(" ") ? "#\(oldName)#" : "#\(oldName)"
-            let newHash = newName.contains(" ") ? "#\(newName)#" : "#\(newName)"
-
             var updatedCount = 0
 
             for (_, note) in cache.notes {
                 if note.trashed { continue }
-                if !note.text.contains(oldHash) { continue }
+                // Pre-filter on the indexed tag strings. This is faster than a
+                // full-body scan and also catches notes whose CloudKit index
+                // holds `oldName` via ancestor expansion even though the body
+                // never spells it out literally (e.g. body has `#foo/bar` but
+                // the index includes `foo`).
+                if !note.tags.contains(oldName) { continue }
 
                 let record = try await api.lookupRecords(ids: [note.recordName]).first
                 guard let record = record else { continue }
 
-                let newText = note.text.replacingOccurrences(of: oldHash, with: newHash)
-                _ = try await api.updateNote(record: record, newText: newText)
+                // Boundary-aware rename in the body. `TagParser.renameTagPrefix`
+                // refuses to match across tag boundaries, so renaming `context`
+                // won't mangle `#contexts` or the unrelated `#context-y`.
+                let newText = TagParser.renameTagPrefix(
+                    in: note.text, from: oldName, to: newName
+                )
+
+                // Update the CloudKit tag index so Bear's sidebar reflects the
+                // rename immediately — previously the body was rewritten but
+                // `tagsStrings` / `tags` were stale until Bear re-parsed.
+                let (tagUUIDs, tagStringValues) = try await buildTagMetadata(
+                    api: api, record: record, adding: newName, removing: oldName
+                )
+                _ = try await api.updateNote(
+                    record: record, newText: newText,
+                    tagUUIDs: tagUUIDs, tagStrings: tagStringValues
+                )
                 updatedCount += 1
             }
 
@@ -295,43 +312,56 @@ struct TagDelete: ParsableCommand {
             let engine = SyncEngine(api: api)
             let cache = try await engine.ensureCacheReady()
 
-            let tagHash = tagName.contains(" ") ? "#\(tagName)#" : "#\(tagName)"
             var updatedCount = 0
 
             for (_, note) in cache.notes {
                 if note.trashed { continue }
-                if !note.text.contains(tagHash) { continue }
+                // Pre-filter on the indexed tag strings. This visits notes
+                // whose CloudKit index contains `tagName` even when the body
+                // has no literal `#tagName` token — that's the phantom-ancestor
+                // case (body has `#foo/bar`, index also carries `foo`).
+                if !note.tags.contains(tagName) { continue }
 
                 let record = try await api.lookupRecords(ids: [note.recordName]).first
                 guard let record = record else { continue }
 
-                // Remove the tag from the text
-                let lines = note.text.components(separatedBy: "\n")
-                var newLines: [String] = []
-                for line in lines {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    if trimmed == tagHash { continue }
-                    var modified = line.replacingOccurrences(of: " \(tagHash)", with: "")
-                    modified = modified.replacingOccurrences(of: "\(tagHash) ", with: "")
-                    modified = modified.replacingOccurrences(of: tagHash, with: "")
-                    newLines.append(modified)
-                }
-                let newText = newLines.joined(separator: "\n")
+                // Boundary-aware body strip. `TagParser.stripTag` refuses to
+                // truncate `#foo/bar` when removing `foo`.
+                let newText = TagParser.stripTag(from: note.text, name: tagName)
 
-                if newText != note.text {
-                    _ = try await api.updateNote(record: record, newText: newText)
-                    updatedCount += 1
-                }
+                // Update the CloudKit tag index so Bear's sidebar reflects
+                // the removal — previously the body was rewritten but
+                // `tagsStrings` / `tags` were stale until Bear re-parsed.
+                let (tagUUIDs, tagStringValues) = try await buildTagMetadata(
+                    api: api, record: record, removing: tagName
+                )
+                _ = try await api.updateNote(
+                    record: record, newText: newText,
+                    tagUUIDs: tagUUIDs, tagStrings: tagStringValues
+                )
+                updatedCount += 1
+            }
+
+            // Finally, delete the SFNoteTag record itself so the tag no longer
+            // appears in `bear_get_tags` or Bear's sidebar. Without this step
+            // the tag record persists as a phantom with a stale `notesCount`.
+            var tagRecordDeleted = false
+            if let tagRecord = try await api.findTagRecord(byName: tagName) {
+                try await api.deleteRecord(recordName: tagRecord.recordName)
+                tagRecordDeleted = true
             }
 
             if json {
                 let output: [String: Any] = [
-                    "tag": tagName, "notesUpdated": updatedCount, "deleted": true,
+                    "tag": tagName,
+                    "notesUpdated": updatedCount,
+                    "deleted": tagRecordDeleted,
                 ]
                 if let data = try? JSONSerialization.data(withJSONObject: output, options: .prettyPrinted),
                    let str = String(data: data, encoding: .utf8) { print(str) }
             } else {
-                print("Deleted tag '\(tagName)' from \(updatedCount) notes")
+                let deletedNote = tagRecordDeleted ? "" : " (tag record not found)"
+                print("Deleted tag '\(tagName)' from \(updatedCount) notes\(deletedNote)")
             }
         }
     }

--- a/Sources/BearCLICore/Commands/TagCommand.swift
+++ b/Sources/BearCLICore/Commands/TagCommand.swift
@@ -361,18 +361,9 @@ private func buildTagMetadata(
     }
 
     if let remove = removing {
-        currentStrings.removeAll(where: { $0 == remove })
-        // If the removed tag was hierarchical, drop ancestors that are now orphaned.
-        let parts = remove.split(separator: "/").map(String.init)
-        if parts.count > 1 {
-            for i in 1..<parts.count {
-                let ancestor = parts.prefix(i).joined(separator: "/")
-                let stillHasDescendant = currentStrings.contains { $0.hasPrefix(ancestor + "/") }
-                if !stillHasDescendant {
-                    currentStrings.removeAll(where: { $0 == ancestor })
-                }
-            }
-        }
+        currentStrings = TagParser.remainingTagsAfterRemoval(
+            from: currentStrings, removing: remove
+        )
     }
 
     let nameToUUID = try await api.ensureTagsExist(names: currentStrings)

--- a/Sources/BearCLICore/TagParser.swift
+++ b/Sources/BearCLICore/TagParser.swift
@@ -78,6 +78,37 @@ public enum TagParser {
         }
     }
 
+    /// Compute the new indexed-tag list after removing `tag` from `strings`,
+    /// additionally pruning any ancestor that no longer has a descendant in
+    /// the result. Input order of surviving entries is preserved.
+    ///
+    /// The ancestor pass walks **deep → shallow** so that each ancestor's
+    /// "do I still have a descendant?" check sees the removals made in prior
+    /// iterations. Walking shallow → deep strands the shallowest ancestor:
+    /// given `["a/b/c", "a/b", "a"]` and removal of `"a/b/c"`, the old order
+    /// left `"a"` in the result because `"a/b"` was still present when `"a"`
+    /// was evaluated. See the matching unit tests.
+    ///
+    /// Pure and order-stable — safe to unit-test without CloudKit.
+    public static func remainingTagsAfterRemoval(
+        from strings: [String], removing tag: String
+    ) -> [String] {
+        var result = strings
+        result.removeAll(where: { $0 == tag })
+
+        let parts = tag.split(separator: "/").map(String.init)
+        guard parts.count > 1 else { return result }
+
+        for i in (1..<parts.count).reversed() {
+            let ancestor = parts.prefix(i).joined(separator: "/")
+            let stillHasDescendant = result.contains { $0.hasPrefix(ancestor + "/") }
+            if !stillHasDescendant {
+                result.removeAll(where: { $0 == ancestor })
+            }
+        }
+        return result
+    }
+
     /// Remove every occurrence of `#tagName` (or `#multi word tag#`) from a
     /// markdown body, honouring tag-boundary rules so that stripping `parent`
     /// does not truncate `#parent/child`. Collapses the adjacent space so the

--- a/Tests/BearCLITests/TagParserTests.swift
+++ b/Tests/BearCLITests/TagParserTests.swift
@@ -174,6 +174,75 @@ final class TagParserAncestorsTests: XCTestCase {
     }
 }
 
+final class TagParserRemoveTests: XCTestCase {
+
+    func testRemoveFlatTag() {
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(from: ["foo", "bar"], removing: "foo"),
+            ["bar"]
+        )
+    }
+
+    func testRemoveTagNotPresentIsNoOp() {
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(from: ["foo", "bar"], removing: "baz"),
+            ["foo", "bar"]
+        )
+    }
+
+    func testRemoveLeafDropsAllOrphanedAncestors() {
+        // The Issue A regression. Before the deep→shallow walk, this returned
+        // `["a"]`: when ancestor `a` was evaluated, `a/b` was still present so
+        // `a` was kept; then `a/b` was removed but `a` was never re-checked.
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(
+                from: ["a/b/c", "a/b", "a"], removing: "a/b/c"
+            ),
+            []
+        )
+    }
+
+    func testRemoveLeafKeepsAncestorWhenSiblingSurvives() {
+        // `a/d` is a descendant of `a`, so `a` must survive the cleanup when
+        // `a/b/c` (and its unique ancestor `a/b`) are removed.
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(
+                from: ["a/b/c", "a/b", "a", "a/d"], removing: "a/b/c"
+            ),
+            ["a", "a/d"]
+        )
+    }
+
+    func testRemoveTwoLevelLeaf() {
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(
+                from: ["parent/child", "parent"], removing: "parent/child"
+            ),
+            []
+        )
+    }
+
+    func testRemoveMiddleOfHierarchy() {
+        // Removing `a/b` when `a/b/c` is still indexed should leave the leaf
+        // and its required ancestor chain intact.
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(
+                from: ["a/b/c", "a/b", "a"], removing: "a/b"
+            ),
+            ["a/b/c", "a"]
+        )
+    }
+
+    func testRemovePreservesInputOrder() {
+        XCTAssertEqual(
+            TagParser.remainingTagsAfterRemoval(
+                from: ["zeta", "a/b", "a", "middle"], removing: "a/b"
+            ),
+            ["zeta", "middle"]
+        )
+    }
+}
+
 final class TagParserStripTests: XCTestCase {
 
     func testStripSimpleTag() {


### PR DESCRIPTION
# PR title

Fix tag-index staleness, body-edit corruption, and phantom SFNoteTag records

# PR body

## Summary

Three tag-management bugs that surfaced while stress-testing commit 941fbc4. All three are independent root causes, all three are in the same code neighbourhood (`Commands/TagCommand.swift` + `CloudKitAPI.swift`), and the fix for each makes the others easier to reason about — so they're bundled here. The PR is two commits (one per root cause cluster) for reviewability; happy to split into separate PRs if you prefer.

### 1. `bear_remove_tag` leaves the root ancestor stranded

Given a note whose only body hashtag is `#a/b/c`:

```
$ bear_create_note body:"#a/b/c"
# CloudKit indexes tagsStrings: ["a/b/c", "a/b", "a"]
$ bear_remove_tag "a/b/c"
# expected tagsStrings: []
# actual   tagsStrings: ["a"]
```

**Cause.** `buildTagMetadata` walks the removed tag's ancestors shallow → deep while mutating `currentStrings` in place. The shallowest ancestor is evaluated first, when its deeper descendants are still present, so it looks alive and is kept. By the time the descendants are removed, the shallow check never runs again:

```
currentStrings = ["a/b/c", "a/b", "a"] ; removing "a/b/c"
i=1 ancestor="a"   : "a/b" starts with "a/"     → keep "a"    (stale)
i=2 ancestor="a/b" : nothing starts with "a/b/" → drop "a/b"
result: ["a"]   ← "a" is stranded
```

**Fix.** Walk deep → shallow. Each ancestor's "do I still have a descendant?" check then sees the prior iterations' removals and reflects reality. The multi-branch case is preserved: `["a/b/c", "a/b", "a", "a/d"]` removing `"a/b/c"` still keeps `"a"` alive because `"a/d"` remains.

Extracted the cleanup into `TagParser.remainingTagsAfterRemoval(from:removing:)` — a pure function — so the regression can be covered with deterministic unit tests alongside the existing TagParser helpers.

### 2. `bear_rename_tag` and `bear_delete_tag` corrupt adjacent tokens, and leave the tag index stale

Both commands used substring-level contains-and-replace on note bodies:

- `bear_rename_tag context projects` on a note containing `#contexts` (plural) rewrote it to `#projectss`.
- `bear_delete_tag parent` on a note containing `#parent/child` produced `#/child`.

Both commands also skipped the CloudKit tag index — `api.updateNote` was called without `tagUUIDs` / `tagStrings`, so `tagsStrings` and `tags` stayed stale until Bear re-parsed the note.

**Fix.** Route body edits through the already-tested boundary-aware helpers (`TagParser.renameTagPrefix` and `TagParser.stripTag`) and pass the refreshed tag metadata to `updateNote`. Pre-filter visited notes on `note.tags.contains(name)` — faster than a body scan and, importantly, catches phantom-ancestor cases where the tag is in the CloudKit index but no literal hashtag exists in the body.

### 3. `bear_delete_tag` never actually deletes the `SFNoteTag` record

`TagDelete.run()` returned `deleted: true` unconditionally while only editing note bodies. The `SFNoteTag` record itself was never touched, so the tag persisted in `bear_get_tags` with a stale `notesCount` after every note had been stripped. bcli had no CloudKit delete path at all — every "delete" in the codebase was a soft-delete via update.

**Fix.** Add `CloudKitAPI.deleteRecord(recordName:)` using a `forceDelete` op (matches the existing `modifyRecords` flow; `CKModifyRecordResult.deleted` was already parsed). Add `CloudKitAPI.findTagRecord(byName:)` using a server-side `title` equality filter. `TagDelete.run()` now calls both after the per-note loop and surfaces whether the tag record was actually removed in its output:

```
# before
$ bear_delete_tag foo
{"tag": "foo", "notesUpdated": 2, "deleted": true}         # lies
$ bear_get_tags                                             # foo still listed

# after
$ bear_delete_tag foo
{"tag": "foo", "notesUpdated": 2, "deleted": true}          # actually deleted
$ bear_get_tags                                             # foo gone
```

## Commits

1. `Fix orphan-ancestor cleanup when removing a hierarchical tag` — 3 files, +103 / −12.
2. `Boundary-aware TagRename/TagDelete + actual SFNoteTag deletion` — 2 files, +99 / −26.

## Tests

- Commit 1 adds `TagParserRemoveTests` in `Tests/BearCLITests/TagParserTests.swift` — 7 deterministic tests pinning the regression (`["a/b/c", "a/b", "a"]` remove `"a/b/c"` → `[]`), the multi-branch preservation, middle-of-hierarchy removal, and order stability.
- `TagParser.stripTag` and `TagParser.renameTagPrefix` (used by commit 2) are already covered by the existing `TagParserStripTests` and `TagParserRemovePrefixTests` suites.
- No unit tests for the CloudKit `forceDelete` path — it's an integration seam that needs exercising against a real account. I verified the wire shape matches the `modifyRecords` flow the file already uses and confirmed `CKModifyRecordResult.deleted` is already decoded; end-to-end verification is a `bear_delete_tag` on a disposable tag.

## What this PR does not fix

**`notesCount` on `SFNoteTag` is stored and never decremented.** `buildCreateTagOperation` writes `notesCount: 1` at creation (`CloudKitAPI.swift:953`) and nothing updates it afterward. This produces phantom `notesCount: 1` readings on tags whose last note has been removed but whose SFNoteTag record still exists. Once this PR lands, `bear_delete_tag` removes those SFNoteTag records outright so the symptom disappears for the common case, but any tag whose last note was trashed via `bear_remove_tag` (rather than `bear_delete_tag`) still shows a stale count. Happy to follow up with either a read-time derivation or a counter-maintenance pass if you'd like — they're plausible but require their own design discussion.

**Note-cache staleness.** `TagRename.run()` and `TagDelete.run()` compute `newText` from `note.text` in the sync cache. If another device edited the note between the last sync and this command, those edits would be overwritten. This matches the pre-PR behaviour and is out of scope here.
